### PR TITLE
config_tools: specify widgets in XML schema

### DIFF
--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm.vue
@@ -1,4 +1,10 @@
 <template>
+  <textarea>
+    {{currentFormSchema.BasicConfigType}}
+  </textarea>
+  <textarea>
+    {{currentFormData}}
+  </textarea>
   <div style="position: relative">
     <b-button
         variant="primary"
@@ -56,6 +62,11 @@ import VueForm, {i18n} from "@lljj/vue3-form-naive"
 import {Icon} from "@vicons/utils";
 import {Minus} from "@vicons/fa"
 import localizeEn from 'ajv-i18n/localize/en';
+import IVSHMEM_REGION from "./ConfigForm/CustomWidget/IVSHMEM_REGION";
+
+
+
+
 
 
 i18n.useLocal(localizeEn);
@@ -77,7 +88,38 @@ export default {
         "labelWidth": "300px",
         "labelSuffix": "："
       },
-      uiSchema: {}
+      uiSchema: {
+        "FEATURES": {
+          "IVSHMEM": {
+            "ui:title": "InterVM shared memory",
+            "IVSHMEM_REGION": {
+              "ui:title": "",
+              "ui:sortable": false,
+              "ui:widget": IVSHMEM_REGION,
+              "items": {
+                "IVSHMEM_VMS": {
+                  "IVSHMEM_VM": {
+                    "ui:sortable": false,
+                    "items": {
+                      "VBDF": {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "vuart_connections": {
+          "vuart_connection": {
+            "ui:sortable": false,
+            "items": {
+              "endpoint": {
+                "ui:sortable": false
+              }
+            }
+          }
+        }
+      }
     };
   },
   methods: {

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
@@ -1,0 +1,13 @@
+<template>
+$END$
+</template>
+
+<script>
+export default {
+name: "IVSHMEM_REGION"
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
+++ b/misc/config_tools/configurator/packages/configurator/src/pages/Config/ConfigForm/CustomWidget/IVSHMEM_REGION.vue
@@ -1,13 +1,143 @@
 <template>
-$END$
+  <div class="IVSH_REGIONS">
+    <div class="IVSH_REGION" v-for="(IVSHMEM_VMO, index) in modelValue">
+      <div class="IVSH_REGION_CONTENT">
+        <b style="margin-bottom: 2rem">InterVM shared memory region {{ index + 1 }}</b>
+
+        <table style="padding: 2rem 0 0 0">
+          <tbody>
+          <tr>
+            <td>
+              <label>Region name: </label>
+            </td>
+            <td><input v-model="IVSHMEM_VMO.NAME"/></td>
+          </tr>
+          <tr>
+            <td>
+              <label>Emulated by: </label>
+            </td>
+            <td><input v-model="IVSHMEM_VMO.PROVIDED_BY"/></td>
+          </tr>
+          <tr>
+            <td>
+              <label>Size (MB):  </label>
+            </td>
+            <td><input v-model="IVSHMEM_VMO.IVSHMEM_SIZE"/></td>
+          </tr>
+          </tbody>
+        </table>
+
+        <div style="padding: 2rem 2rem 1rem 0">
+          <b>Shared VMs</b>
+          <p>Select all VMs that will use this shared memory region</p>
+          <table>
+            <thead>
+            <tr>
+              <th></th>
+              <td>Virtual BDF</td>
+            </tr>
+            </thead>
+            <tbody>
+            <tr v-for="IVSHMEM_VM in IVSHMEM_VMO.IVSHMEM_VMS.IVSHMEM_VM">
+              <td>
+                VM name:
+                <b-form-select>
+                  <b-form-select-option>
+                    {{ IVSHMEM_VM.VM_NAME }}
+                  </b-form-select-option>
+                </b-form-select>
+              </td>
+              <td>
+                <label>Emulated by: <input v-model="IVSHMEM_VM.VBDF"/></label>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="ToolSet">
+        <Icon size="18px" @click="removeThisVMO">
+          <Minus/>
+        </Icon>
+        <Icon size="18px" @click="addIVSHMEM_VMO">
+          <Plus/>
+        </Icon>
+      </div>
+
+    </div>
+
+  </div>
 </template>
 
 <script>
+import _ from 'lodash';
+import {Icon} from "@vicons/utils";
+import {Plus, Minus} from '@vicons/fa'
+import {BFormSelect, BFormSelectOption} from "bootstrap-vue-3";
+
 export default {
-name: "IVSHMEM_REGION"
+  name: "IVSHMEM_REGION",
+  components: {BFormSelectOption, BFormSelect, Icon, Plus, Minus},
+  props: {
+    modelValue: {
+      type: null,
+      default: ''
+    },
+  }, methods: {
+    removeThisVMO(index) {
+      this.modelValue.splice(index, 1);
+    },
+    addIVSHMEM_VMO() {
+      if (!_.isArray(this.modelValue)) {
+        this.modelValue = []
+      }
+      this.modelValue.push({
+        "NAME": "shm_region_" + this.modelValue.length,
+        "PROVIDED_BY": "Hypervisor",
+        "IVSHMEM_SIZE": "2",
+        "IVSHMEM_VMS": {
+          "IVSHMEM_VM": [
+            {
+              "VM_NAME": "PRE_RT_VM0",
+              "VBDF": ""
+            },
+            {
+              "VM_NAME": "POST_STD_VM1",
+              "VBDF": ""
+            }
+          ]
+        }
+      })
+    }
+  }
 }
 </script>
 
 <style scoped>
+label {
+  display: block;
+}
 
+.IVSH_REGION {
+  display: flex;
+  align-items: start;
+}
+
+.IVSH_REGION_CONTENT {
+  border: 1px solid gray;
+  border-radius: 5px;
+  padding: 25px;
+  margin: 1rem 0 2rem;
+}
+
+.ToolSet {
+  margin: 1rem 0 2rem;
+  padding: 0 1rem;
+}
+.xicon{
+  margin: 8px;
+  border: 1px solid gray;
+  border-radius: 3px;
+  background: lightgray;
+}
 </style>

--- a/misc/config_tools/configurator/packages/vue-json-schema-form/utils/style/baseForm.scss
+++ b/misc/config_tools/configurator/packages/vue-json-schema-form/utils/style/baseForm.scss
@@ -154,12 +154,11 @@
         box-shadow: 0 3px 1px -2px rgba(0,0,0,0.2), 0 0 3px 1px rgba(0,0,0,0.1);
     }
     .arrayOrderList_item {
-        position: relative;
         padding: 25px 10px 12px;
         border-radius: 2px;
         margin-bottom: 6px;
         display: flex;
-        align-items: center;
+        align-items: end;
     }
     .arrayOrderList_bottomAddBtn {
         text-align: right;
@@ -174,13 +173,13 @@
     }
     .arrayListItem_content {
         padding-top: 15px;
+        padding-right: 15px;
         flex: 1;
         margin: 0 auto;
-        box-shadow: 0 -1px 0 0 rgba(0,0,0,0.05);
+        border: 1px solid rgba(0,0,0,0.05);
     }
 
     .arrayListItem_index, .arrayListItem_operateTool{
-        position: absolute;
         height: 25px;
     }
     .arrayListItem_index {

--- a/misc/config_tools/configurator/packages/vue-json-schema-form/vue3/vue3-core/src/components/Widget.js
+++ b/misc/config_tools/configurator/packages/vue-json-schema-form/vue3/vue3-core/src/components/Widget.js
@@ -296,6 +296,7 @@ export default {
                         }, [
                             ...miniDescriptionVNode ? [miniDescriptionVNode] : [],
                             `${label}`,
+                           // `${props.curNodePath}`,
                             `${(props.formProps && props.formProps.labelSuffix) || ''}`
                         ])
                     } : {},

--- a/misc/config_tools/configurator/packages/vue-json-schema-form/vue3/vue3-core/src/fields/ArrayField/components/ArrayOrderList.js
+++ b/misc/config_tools/configurator/packages/vue-json-schema-form/vue3/vue3-core/src/fields/ArrayField/components/ArrayOrderList.js
@@ -110,6 +110,15 @@ export default {
                                 'div',
                                 {
                                     class: {
+                                        arrayListItem_content: true
+                                    }
+                                },
+                                [VNodeItem]
+                            ),
+                            h(
+                                'div',
+                                {
+                                    class: {
                                         arrayListItem_operateTool: true
                                     }
                                 },
@@ -194,15 +203,6 @@ export default {
                                         [h(IconClose)]
                                     )
                                 ]
-                            ),
-                            h(
-                                'div',
-                                {
-                                    class: {
-                                        arrayListItem_content: true
-                                    }
-                                },
-                                [VNodeItem]
                             )
                         ]
                     );

--- a/misc/config_tools/scenario_config/jsonschema/converter.py
+++ b/misc/config_tools/scenario_config/jsonschema/converter.py
@@ -145,6 +145,12 @@ class XS2JS:
         json_schema["definitions"] = self._get_definitions()
         return json_schema
 
+    def convert_widget_config(self, annotation, js_ele):
+        if '@acrn:widget' in annotation:
+            js_ele['ui:widget'] = annotation['@acrn:widget']
+            if '@acrn:widget-options' in annotation:
+                js_ele['ui:options'] = {eval(k): eval(v) for k, v in [kv.split('=') for kv in annotation['@acrn:widget-options'].split(',')]}
+
     def xst2jst(self, type_name) -> str:
         """convert xml schema type name to json schema type name"""
         if type_name in self.xst2jst_mapping:
@@ -188,6 +194,10 @@ class XS2JS:
                             print('Warning!: enum element {} does not provide a enumName'.format(str(enum_element)))
                             enum_names.append(enum_name)
                     js_st["enumNames"] = enum_names
+
+                # widget and its options
+                if 'xs:annotation' in obj:
+                    self.convert_widget_config(obj['xs:annotation'], js_st)
 
             js_st.update(self.xsa2jsa(restriction))
             return js_st
@@ -333,6 +343,9 @@ class XS2JS:
                         'sorted': element['xs:annotation'].get('@acrn:options-sorted-by', None)
                     }
                     js_ele['enum'] = dynamic_enum
+
+                # widget and its options
+                self.convert_widget_config(element['xs:annotation'], js_ele)
 
             properties[name] = js_ele
 

--- a/misc/config_tools/schema/types.xsd
+++ b/misc/config_tools/schema/types.xsd
@@ -4,7 +4,7 @@
 	   xmlns:acrn="https://projectacrn.org">
 
 <xs:simpleType name="Boolean">
-  <xs:annotation>
+  <xs:annotation acrn:widget="b-form-checkbox" acrn:widget-options="'value' = 'y', 'unchecked-value' = 'n'">
     <xs:documentation>A Boolean value, written as ``y`` or ``n``.</xs:documentation>
   </xs:annotation>
   <xs:restriction base="xs:string">


### PR DESCRIPTION
This patch introduces two annotation attributes in the XML schema in
order to specify and configure the widgets to be used when rendering
the config items. The new attributes are:

    - acrn:widget, which converts to ui:widget in uiSchema

    - acrn:widget-options, which is a comma-separated key-value
       string and converts to ui:options in uiSchema

Tracked-On: #6689
Signed-off-by: Junjie Mao <junjie.mao@intel.com>