### PR TITLE
config_tools: populate default values to empty nodes

### DIFF
--- a/misc/config_tools/scenario_config/default_populator.py
+++ b/misc/config_tools/scenario_config/default_populator.py
@@ -58,6 +58,11 @@ class DefaultValuePopulator(ScenarioTransformer):
 
         return [new_node]
 
+    def fill_empty_node(self, xsd_element_node, xml_parent_node, xml_empty_node):
+        default_value = self.get_default_value(xsd_element_node, xml_parent_node)
+        if default_value is not None:
+            xml_empty_node.text = default_value
+
 class DefaultValuePopulatingStage(PipelineStage):
     uses = {"schema_etree", "scenario_etree"}
     provides = {"scenario_etree"}

--- a/misc/config_tools/scenario_config/scenario_transformer.py
+++ b/misc/config_tools/scenario_config/scenario_transformer.py
@@ -68,7 +68,10 @@ class ScenarioTransformer:
                     self.add_and_transform_missing_node(xsd_element_node, xml_node, new_node_index=index)
             else:
                 while len(children) > 0 and children[0][1].tag == element_name:
-                    self.transform_node(xsd_element_node, children.pop(0)[1])
+                    xml_child_node = children.pop(0)[1]
+                    if self.complex_type_of_element(xsd_element_node, xml_child_node) is None and not xml_child_node.text:
+                        self.fill_empty_node(xsd_element_node, xml_node, xml_child_node)
+                    self.transform_node(xsd_element_node, xml_child_node)
 
     def transform_all(self, xsd_all_node, xml_node):
         for xsd_element_node in xsd_all_node.findall("xs:element", namespaces=self.xpath_ns):
@@ -83,6 +86,8 @@ class ScenarioTransformer:
                     self.add_and_transform_missing_node(xsd_element_node, xml_node)
             else:
                 for xml_child_node in xml_children:
+                    if self.complex_type_of_element(xsd_element_node, xml_child_node) is None and not xml_child_node.text:
+                        self.fill_empty_node(xsd_element_node, xml_node, xml_child_node)
                     self.transform_node(xsd_element_node, xml_child_node)
 
     def add_and_transform_missing_node(self, xsd_element_node, xml_parent_node, new_node_index=None):
@@ -91,6 +96,9 @@ class ScenarioTransformer:
 
     def add_missing_nodes(self, xsd_element_node, xml_parent_node, new_node_index):
         return []
+
+    def fill_empty_node(self, xsd_element_node, xml_parent_node, xml_empty_node):
+        pass
 
     def transform(self, xml_etree):
         self.xml_etree = xml_etree


### PR DESCRIPTION
This patch allows the default value populator to fill in empty nodes whose
default values are specified in the XML schema.

Tracked-On: #6690
Signed-off-by: Junjie Mao <junjie.mao@intel.com>